### PR TITLE
Revert nodocs

### DIFF
--- a/config_generator.py
+++ b/config_generator.py
@@ -76,7 +76,7 @@ def generate_config():
     print_conf("config_opts['chroot_setup_cmd'] = ('install', 'basesystem-build', 'dwz', 'dnf')")
     print_conf("config_opts['package_manager'] = 'dnf'")
     print_conf(
-        "config_opts['dnf_common_opts'] = ['--refresh', '--disableplugin=local', '--setopt=deltarpm=False', '--setopt=install_weak_deps=False', '--setopt=tsflags=nodocs', '--forcearch=%s']" % platform_arch)
+        "config_opts['dnf_common_opts'] = ['--refresh', '--disableplugin=local', '--setopt=deltarpm=False', '--setopt=install_weak_deps=False', '--forcearch=%s']" % platform_arch)
     print_conf(
         "config_opts['dnf_builddep_opts'] = ['--refresh', '--forcearch=%s']" % platform_arch)
     print_conf("config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgid}} -d {{chroothome}} {{chrootuser}}'")


### PR DESCRIPTION
qt5 devel packages store files in /usr/share/doc,
those files are used when other packages are built

Example of build failure after this change:
https://abf.io/build_lists/3822172 (qt-creator)
"error: Cannot open file '/usr/share/doc/qt5/global/qt-html-templates-offline.qdocconf': No such file or directory"

Fixes: 296429e7e ("skip installing weak deps and docs")

cc @tpgxyz @fedya 