### PR TITLE
Revert "Revert nodocs"

### DIFF
--- a/config_generator.py
+++ b/config_generator.py
@@ -76,7 +76,7 @@ def generate_config():
     print_conf("config_opts['chroot_setup_cmd'] = ('install', 'basesystem-build', 'dwz', 'dnf')")
     print_conf("config_opts['package_manager'] = 'dnf'")
     print_conf(
-        "config_opts['dnf_common_opts'] = ['--refresh', '--disableplugin=local', '--setopt=deltarpm=False', '--setopt=install_weak_deps=False', '--forcearch=%s']" % platform_arch)
+        "config_opts['dnf_common_opts'] = ['--refresh', '--disableplugin=local', '--setopt=deltarpm=False', '--setopt=install_weak_deps=False', '--setopt=tsflags=nodocs', '--forcearch=%s']" % platform_arch)
     print_conf(
         "config_opts['dnf_builddep_opts'] = ['--refresh', '--forcearch=%s']" % platform_arch)
     print_conf("config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgid}} -d {{chroothome}} {{chrootuser}}'")


### PR DESCRIPTION
Reverts OpenMandrivaSoftware/docker-builder#34

Please revert, as broken spec files should be fixed properly instead of messing around here. We have opportunity to speed up build process by omiting installing useless stuff like man, info etc.

For those who do not know how to fix things:  https://github.com/OpenMandrivaAssociation/qt5-qtbase/blob/95f1f12fd2fc111c1d73fe8bbfafe6b0b01ca76f/qt5-qtbase.spec#L6