### PR TITLE
Clean up base chroot

### DIFF
--- a/config_generator.py
+++ b/config_generator.py
@@ -79,7 +79,7 @@ def generate_config():
         print_conf("config_opts['legal_host_arches'] = ('i586', 'i686', 'x86_64')")
 
     print_conf("config_opts['root'] = '%s-%s'" % (platform_name, platform_arch))
-    print_conf("config_opts['chroot_setup_cmd'] = ('install', 'basesystem-build', 'dwz', 'dnf', 'magic-devel')")
+    print_conf("config_opts['chroot_setup_cmd'] = ('install', 'basesystem-build')")
     print_conf("config_opts['package_manager'] = 'dnf'")
     if platform_arch != 'e2kv4':
         if os.getenv('PACKAGE') and os.getenv('PACKAGE')[:4] == 'qt5-':


### PR DESCRIPTION
dnf from host is used, it us not needed in the base chroot. Having dnf here makes bootstraping new versions of python3 harder. magic-devel, dwz etc. must be pulled from basesystem-build, no idea why they are here.